### PR TITLE
lint fixes

### DIFF
--- a/Model/FDSError.go
+++ b/Model/FDSError.go
@@ -14,7 +14,7 @@ type FDSError struct {
 }
 
 func (e *FDSError) Error() string {
-	return fmt.Sprintf("%s %s Code: [%d] Msg: ", e.time.Format(time.ANSIC), e.funcName, e.code, e.msg)
+	return fmt.Sprintf("%s %s Code: [%d] Msg: %s", e.time.Format(time.ANSIC), e.funcName, e.code, e.msg)
 }
 
 func (e *FDSError) Code() int {

--- a/util.go
+++ b/util.go
@@ -631,7 +631,7 @@ func (c *FDSClient) Download_Object(bucketname, objectname, filename string) (*s
 		Content_Type: "",
 		Headers:      &headers,
 	}
-	var i int64 = 0
+	var i int64
 	// 如果要下载的文件大于50MB，则按照每个50MB分段下载，最后一个分片可以小于50MB
 	for ; i < slices; i++ {
 		var partSize int64


### PR DESCRIPTION
```
Model/FDSError.go:17: Sprintf call needs 3 args but has 4 args
util.go:634: should drop = 0 from declaration of var i; it is the zero value
```